### PR TITLE
style: use sentence case for command name

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -15,7 +15,7 @@ export default class ObsidianBTW extends Plugin {
 
     this.addCommand({
       id: "new-terminal",
-      name: "New Terminal",
+      name: "New terminal",
       callback: () => this.createTerminal(),
     })
 


### PR DESCRIPTION
- Change command name from 'New Terminal' to 'New terminal'
- Follows Obsidian UI text guidelines for sentence case
- Improves consistency with Obsidian's own command naming